### PR TITLE
Provide branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,10 @@
     ],
     "require": {
         "php": ">=5.0.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Adding a branch alias lets composer and packagist know that continued development on master equates to the 1.1.\* versions.

If you release a 1.2 or 2.0, update it at the same time.
