### PR TITLE
temp filename also should be escaped

### DIFF
--- a/WkHtmlToPdf.php
+++ b/WkHtmlToPdf.php
@@ -284,7 +284,7 @@ class WkHtmlToPdf
             $command .= $this->renderOptions($object);
         }
 
-        return $command.' '.$filename;
+        return $command.' '.$this->escape($filename);
     }
 
     /**


### PR DESCRIPTION
On Windows temp filename can contain spaces (for example, C:\Documents and Settings\Username\Local Settings\Temp\tmp568.tmp). In this case call of wkhtmltopdf fails.
