### PR TITLE
Added a new method to the Pdf Class (pdf::buildCommand) so that we can g...

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ I also found that some options don't work on Windows (tested with wkhtmltopdf 0.
 `user-style-sheet` option used in the example below.
 
 
+### Warning: proc_open(): CreateProcess failed
+
+In some versions of PHP for Windows, `proc_open()` does not work properly. If you experience this, you can use `exec()`
+to run the command as a workaround:
+
+```
+$pdf = new Pdf();
+$pdf->addPage('http://google.com');
+$cmd = $pdf->buildCommand()->getExecCommand();
+exec($cmd);
+```
+
+
 ## Setup for different wkhtmltopdf versions
 
 As mentioned before the PHP class is just a convenient frontend for the `wkhtmltopdf` command. So you need to

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -236,14 +236,9 @@ class Pdf
         if ($this->_isCreated) {
             return false;
         }
-        $command = $this->getCommand();
         $fileName = $this->getPdfFilename();
+        $command = $this->buildCommand($fileName);
 
-        $command->addArgs($this->_options);
-        foreach ($this->_objects as $object) {
-            $command->addArgs($object);
-        }
-        $command->addArg($fileName, null, true);    // Always escape filename
         if (!$command->execute()) {
             $this->_error = $command->getError();
             if (!(file_exists($fileName) && filesize($fileName)!==0 && $this->ignoreWarnings)) {
@@ -252,6 +247,30 @@ class Pdf
         }
         $this->_isCreated = true;
         return true;
+    }
+
+
+    /**
+     * Build the Command with the arguments passed
+     *
+     * @param string $fileName The pdf filename
+     * @return \mikehaertl\wkhtmlto\Command
+     */
+    public function buildCommand($fileName = null)
+    {
+        if (is_null($fileName)) {
+            $fileName = $this->getPdfFilename();
+        }
+
+        $command = $this->getCommand();
+
+        $command->addArgs($this->_options);
+        foreach ($this->_objects as $object) {
+            $command->addArgs($object);
+        }
+        $command->addArg($fileName, null, true);    // Always escape filename
+
+        return $command;
     }
 
     /**


### PR DESCRIPTION
Added a new method to the Pdf Class (pdf::buildCommand) so that we can get the full exec command. Useful in windows environments so that you can bypass the proc_open PHP bug.
See this [Issue](https://github.com/mikehaertl/phpwkhtmltopdf/issues/56)

Also added a note to this in the documentation

