### PR TITLE
Use $this in return phpdoc when appropriate

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -92,7 +92,7 @@ class Image
      * Add a page object to the output
      *
      * @param string $page either a URL, a HTML string or a PDF/HTML filename
-     * @return $this the Image instance for method chaining
+     * @return static the Image instance for method chaining
      */
     public function setPage($page)
     {
@@ -139,7 +139,7 @@ class Image
      * Set options
      *
      * @param array $options list of image options to set as name/value pairs
-     * @return $this the Image instance for method chaining
+     * @return static the Image instance for method chaining
      */
     public function setOptions($options=array())
     {

--- a/src/Image.php
+++ b/src/Image.php
@@ -92,7 +92,7 @@ class Image
      * Add a page object to the output
      *
      * @param string $page either a URL, a HTML string or a PDF/HTML filename
-     * @return Image the Image instance for method chaining
+     * @return $this the Image instance for method chaining
      */
     public function setPage($page)
     {
@@ -139,7 +139,7 @@ class Image
      * Set options
      *
      * @param array $options list of image options to set as name/value pairs
-     * @return Image the Image instance for method chaining
+     * @return $this the Image instance for method chaining
      */
     public function setOptions($options=array())
     {

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -102,7 +102,7 @@ class Pdf
      *
      * @param string $input either a URL, a HTML string or a PDF/HTML filename
      * @param array $options optional options for this page
-     * @return Pdf the Pdf instance for method chaining
+     * @return $this the Pdf instance for method chaining
      */
     public function addPage($input,$options=array())
     {
@@ -117,7 +117,7 @@ class Pdf
      *
      * @param string $input either a URL, a HTML string or a PDF/HTML filename
      * @param array $options optional options for the cover page
-     * @return Pdf the Pdf instance for method chaining
+     * @return $this the Pdf instance for method chaining
      */
     public function addCover($input,$options=array())
     {
@@ -131,7 +131,7 @@ class Pdf
      * Add a TOC object to the output
      *
      * @param array $options optional options for the table of contents
-     * @return Pdf the Pdf instance for method chaining
+     * @return $this the Pdf instance for method chaining
      */
     public function addToc($options=array())
     {
@@ -178,7 +178,7 @@ class Pdf
      * Set global option(s)
      *
      * @param array $options list of global PDF options to set as name/value pairs
-     * @return Pdf the Pdf instance for method chaining
+     * @return $this the Pdf instance for method chaining
      */
     public function setOptions($options=array())
     {

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -102,7 +102,7 @@ class Pdf
      *
      * @param string $input either a URL, a HTML string or a PDF/HTML filename
      * @param array $options optional options for this page
-     * @return $this the Pdf instance for method chaining
+     * @return static the Pdf instance for method chaining
      */
     public function addPage($input,$options=array())
     {
@@ -117,7 +117,7 @@ class Pdf
      *
      * @param string $input either a URL, a HTML string or a PDF/HTML filename
      * @param array $options optional options for the cover page
-     * @return $this the Pdf instance for method chaining
+     * @return static the Pdf instance for method chaining
      */
     public function addCover($input,$options=array())
     {
@@ -131,7 +131,7 @@ class Pdf
      * Add a TOC object to the output
      *
      * @param array $options optional options for the table of contents
-     * @return $this the Pdf instance for method chaining
+     * @return static the Pdf instance for method chaining
      */
     public function addToc($options=array())
     {
@@ -178,7 +178,7 @@ class Pdf
      * Set global option(s)
      *
      * @param array $options list of global PDF options to set as name/value pairs
-     * @return $this the Pdf instance for method chaining
+     * @return static the Pdf instance for method chaining
      */
     public function setOptions($options=array())
     {


### PR DESCRIPTION
This allows for proper typehint recognition/code completion for classes extending Pdf and Image.