### PR TITLE
Allow to view raw pdf contents

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -175,6 +175,19 @@ class Pdf
     }
 
     /**
+     * view raw PDF contents
+     * 
+     * @return mixed PDF contents or false if PDF was not created successfully
+     */
+    public function raw()
+    {
+        if (!$this->_isCreated && !$this->createPdf()) {
+            return false;
+        }
+        return file_get_contents($this->_tmpPdfFile->getFileName());
+    }
+
+    /**
      * Set global option(s)
      *
      * @param array $options list of global PDF options to set as name/value pairs


### PR DESCRIPTION
Hi @mikehaertl 

Today I wanted to send a email with a PDF attachment using [apostle.io](https://github.com/apostle/apostle-php) which require the contents of the attachment as a string, e.g.

```php
$mail = new Mail("template-slug");
$mail->addAttachment("test.txt", "Some test text");
$mail->deliver();
```
Correct me if I'm wrong but in `phpwkhtmltopdf` v2.0.4, we're not able to capture the PDF contents into a variable. i.e. this won't work because it's dumped to stdout including some headers:

```php
        $pdf = new mikehaertl\wkhtmlto\Pdf();
        $pdf->addPage('<html>A PDF Test page</html>');
        if (($pdfText = $pdf->send()) === false) {
            echo "Could not create PDF Test Page".$pdf->getError()."\n";
        }
```
I found if I added the following function to `Pdf.php`:

```php
    /**
     * view raw PDF contents
     */
    public function raw()
    {
        if (!$this->_isCreated && !$this->createPdf()) {
            return false;
        }
        return file_get_contents($this->_tmpPdfFile->getFileName());
    }
```
Then it suited my purposes and I could use it like this:

```php
        $pdf = new mikehaertl\wkhtmlto\Pdf();
        $pdf->addPage('<html>A PDF Test page</html>');
        if (($pdfText = $pdf->raw()) === false) {
            echo "Could not create PDF Test Page".$pdf->getError()."\n";
        }
```

Would you consider adding my `raw()` function? I opened a pull request in case it helps but let me know if you have a better implementation (from my experience you always do :smile_cat:  ) . i.e. feel free to ignore me, or propose changes that I can help with.