### PR TITLE
Add __tostring() to view pdf as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ $pdf->send();
 
 // ... or send to client as file download
 $pdf->send('test.pdf');
+
+// ... or you can get the raw pdf as a string
+if (($pdfText = (string) $pdf) === false)
+    echo 'Could not create PDF. '.$pdf->getError();
+
 ```
 
 ### Creating an image

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -175,6 +175,18 @@ class Pdf
     }
 
     /**
+     * Get the raw PDF contents. (triggers PDF creation).
+     * @return string|false The PDF as a string or false if the PDF wasn't created successfully.
+     */
+    public function __toString()
+    {
+        if (!$this->_isCreated && !$this->createPdf()) {
+            return false;
+        }
+        return file_get_contents($this->_tmpPdfFile->getFileName());
+    }
+
+    /**
      * Set global option(s)
      *
      * @param array $options list of global PDF options to set as name/value pairs

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -185,6 +185,21 @@ class PdfTest extends \PHPUnit_Framework_TestCase
         unlink($outFile);
     }
 
+    public function testToString()
+    {
+        $outFile = $this->getOutFile();
+        $binary = $this->getBinary();
+
+        $pdf = new Pdf('<html><h1>Test</h1></html>');
+        $pdf->binary = $binary;
+
+        $this->assertTrue($pdf->saveAs($outFile));
+        $this->assertFileExists($outFile);
+
+        $this->assertEquals(file_get_contents($outFile), (string)$pdf); // Test __toString();
+        unlink($outFile);
+    }
+
     // Options
     public function testCanPassGlobalOptionsInConstructor()
     {


### PR DESCRIPTION
Hi @mikehaertl,

In #109 you suggested to use the `__tostring()` method, this is a pull-request for that approach.

----

I want to send a email with a PDF attachment using [apostle.io](https://github.com/apostle/apostle-php) which require the contents of the attachment as a string, e.g.

```php
$mail = new Mail("template-slug");
$mail->addAttachment("test.txt", "Some test text");
$mail->deliver();
```

With the addition of a `__tostring()` method to `phpwkhtmltopdf` in this pull-request, the following code now works for me:

```php
        $pdf = new mikehaertl\wkhtmlto\Pdf();
        $pdf->addPage('<html>A PDF Test page</html>');
        if (($pdfText = (string) $pdf) === false) {
            echo "Could not create PDF Test Page".$pdf->getError()."\n";
        }

        $result = Yii::app()->mailer->mailAttachment('dev-debugging-mail',['email'=>$email,'subject'=>'Test attachment','message'=>'tom test'],'test.pdf',$pdfText)->send();
```