### PR TITLE
Adds inline detection for <!doctype html tag

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -52,7 +52,7 @@ class Image
     protected $_isCreated = false;
 
     /**
-     * @var mikehaertl\tmp\File|string the page input or a File instance for HTML string inputs
+     * @var \mikehaertl\tmp\File|string the page input or a File instance for HTML string inputs
      */
     protected $_page;
 
@@ -62,7 +62,7 @@ class Image
     protected $_options = array();
 
     /**
-     * @var mikehaertl\tmp\File the temporary image file
+     * @var \mikehaertl\tmp\File the temporary image file
      */
     protected $_tmpImageFile;
 
@@ -112,6 +112,7 @@ class Image
             return false;
         }
         if (!$this->_tmpImageFile->saveAs($filename)) {
+            $tmpFile = $this->_tmpImageFile->getFileName();
             $this->_error = "Could not copy image from tmp location '$tmpFile' to '$filename'";
             return false;
         }
@@ -191,6 +192,7 @@ class Image
 
     /**
      * @return string the mime type for the current image
+     * @throws \Exception
      */
     public function getMimeType()
     {
@@ -201,7 +203,7 @@ class Image
         } elseif ($this->type==='bmp') {
             return 'image/bmp';
         } else {
-            throw new \Excpetion('Invalid image type');
+            throw new \Exception('Invalid image type');
         }
     }
 

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -15,7 +15,7 @@ use mikehaertl\tmp\File;
 class Pdf
 {
     // Regular expression to detect HTML strings
-    const REGEX_HTML = '/<html/i';
+    const REGEX_HTML = '/<(?:!doctype )?html/i';
 
     // Regular expression to detect XML strings
     const REGEX_XML = '/<\??xml/i';
@@ -65,7 +65,7 @@ class Pdf
     protected $_objects = array();
 
     /**
-     * @var mikehaertl\tmp\File the temporary PDF file
+     * @var \mikehaertl\tmp\File the temporary PDF file
      */
     protected $_tmpPdfFile;
 
@@ -271,7 +271,7 @@ class Pdf
 
     /**
      * @param string $input
-     * @return mikehaertl\tmp\File|string a File object if the input is a html string. The unchanged input otherwhise.
+     * @return \mikehaertl\tmp\File|string a File object if the input is a html string. The unchanged input otherwhise.
      */
     protected function processInput($input)
     {


### PR DESCRIPTION
[mikehaertl\wkhtmlto\Pdf::REGEX_HTML](https://github.com/mikehaertl/phpwkhtmltopdf/tree/509ff12/src/Pdf.php#L18) assumes an `<html` tag is present even with the presence of a `<!doctype html` tag. This pull request fixes this behaviour.

(There are also some small IDE doctype hint fixes and a fix for unknown class `Excpetion`).