### PR TITLE
Extends tmp file options

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -23,6 +23,9 @@ class Pdf
     // Regular expression to detect XML strings
     const REGEX_XML = '/<\??xml/i';
 
+    // Regular expression to detect options that expect an URL or a file name, so we need to create a tmp file for the content.
+    const REGEX_OPTS_TMPFILE = '/^((header|footer)-html|(xsl|user)-style-sheet)$/i';
+
     // prefix for tmp files
     const TMP_PREFIX = 'tmp_wkhtmlto_pdf_';
 
@@ -300,7 +303,7 @@ class Pdf
     {
         foreach ($options as $key=>$val) {
             // header-/footer-html, xsl-style-sheet and user-style-sheet expect an URL or a file name, so we need to create a tmp file for the content
-            if (is_string($val) && preg_match('/^((header|footer)-html|xsl-style-sheet|user-style-sheet)$/', $key) ) {
+            if (is_string($val) && preg_match(self::REGEX_OPTS_TMPFILE, $key) ) {
                 defined('PHP_MAXPATHLEN') || define('PHP_MAXPATHLEN', 255);
                 $isFile = (strlen($val) <= PHP_MAXPATHLEN) ? is_file($val) : false;
                 if (!($isFile || preg_match('/^(https?:)?\/\//i',$val) || $val===strip_tags($val))) {

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -299,8 +299,8 @@ class Pdf
     protected function processOptions($options=array())
     {
         foreach ($options as $key=>$val) {
-            // header-/footer-html expect a URL or a file name, so we need to create a tmp file for HTML content
-            if (is_string($val) && preg_match('/^(header|footer)-html$/', $key)) {
+            // header-/footer-html, xsl-style-sheet and user-style-sheet expect an URL or a file name, so we need to create a tmp file for the content
+            if (is_string($val) && preg_match('/^((header|footer)-html|xsl-style-sheet|user-style-sheet)$/', $key) ) {
                 defined('PHP_MAXPATHLEN') || define('PHP_MAXPATHLEN', 255);
                 $isFile = (strlen($val) <= PHP_MAXPATHLEN) ? is_file($val) : false;
                 if (!($isFile || preg_match('/^(https?:)?\/\//i',$val) || $val===strip_tags($val))) {


### PR DESCRIPTION
Adds `xsl-style-sheet` and `user-style-sheet` to the regular expression, which matches options that expect an URL or a file name, so we need to create a tmp file for the content.