### PR TITLE
add --read-args-from-stdin option of wkhtmltopdf

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -285,6 +285,13 @@ class Pdf
             $command->addArgs($object);
         }
         $command->addArg($fileName, null, true);    // Always escape filename
+		
+		if($command->getReadArgsFromStdin())
+		{
+			$configFilename = $this->getConfigFilename($command->getArgs());
+			$command->setOptions(['configFilename'=>$configFilename]);
+		}
+		
         if (!$command->execute()) {
             $this->_error = $command->getError();
             if (!(file_exists($fileName) && filesize($fileName)!==0 && $this->ignoreWarnings)) {
@@ -329,5 +336,15 @@ class Pdf
             }
         }
         return $options;
+    }
+	
+	/**
+     * @return string the filename of the temporary config file
+     */
+    public function getConfigFilename($args)
+    {
+		$tmpConfigFile = new File(str_replace("\\", "\\\\", $args), '.txt', self::TMP_PREFIX, $this->tmpDir);
+		$this->_tmpFiles[] = $tmpConfigFile;
+		return $tmpConfigFile->getFileName();
     }
 }


### PR DESCRIPTION
same update for PDF file.

the framework is limited by the number of characters in the command line:
https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation

https://wkhtmltopdf.org/usage/wkhtmltopdf.txt