### PR TITLE
Add latest changes / versions to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 2.3.1
+
+ * Fix: Issue #264 Problem with tmpDir passed in constructor
+
+## 2.3.0
+
+ * Issue #258 Add toString() method to Image class
+
+## 2.2.2
+
+ * Also create tmp file for xsl-style-sheet and user-style-sheet if required
+
 ## 2.2.1
 
  * Issue #219: Make `header-html` and `footer-html` also work for Toc and cover page


### PR DESCRIPTION
As there's no other place which holds the current version of the library we should update the changelog to provide informatioon about the currently installed version even without composer.