### PR TITLE
Issue #307 Refactor check for temp file creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ composer require mikehaertl/phpwkhtmltopdf
 Make sure, that you include the composer [autoloader](https://getcomposer.org/doc/01-basic-usage.md#autoloading)
 somewhere in your codebase.
 
+## Examples
+
 ### Single page PDF
 
 ```php

--- a/README.md
+++ b/README.md
@@ -188,6 +188,23 @@ $pdf = new Pdf(array(
 ));
 ```
 
+### Passing strings
+
+Some options like `header-html` usually expect a URL or a filename. With our
+library you can also pass a string. The class will try to detect if the
+argument is a URL, a filename or some HTML or XML content.  To make detection
+easier you can surround your content in `<html>` tag.
+
+If this doesn't work correctly you can also pass an instance of our `File`
+helper as a last resort:
+
+```php
+use mikehaertl\tmp\File;
+$options = [
+    'header-html' => new File('Complex content', '.html'),
+];
+```
+
 ## Error handling
 
 `send()`, `saveAs()` and `toString()` will return `false` on error. In this case the detailed error message is

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -315,7 +315,10 @@ class Pdf
      */
     protected function ensureUrlOrFile($input, $type = null)
     {
-        if ($input instanceof File || preg_match(self::REGEX_URL, $input)) {
+        if ($input instanceof File) {
+            $this->_tmpFiles[] = $input;
+            return $input;
+        } elseif (preg_match(self::REGEX_URL, $input)) {
             return $input;
         } elseif ($type === self::TYPE_XML || $type === null && preg_match(self::REGEX_XML, $input)) {
             $ext = '.xml';

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -302,10 +302,11 @@ class Pdf
     }
 
     /**
-     * This method creates a temporary file if the string is neither a URL nor
-     * contains XML or HTML and is also not a valid file name.
+     * This method creates a temporary file if the passed argument is neither a
+     * File instance or URL nor contains XML or HTML and is also not a valid
+     * file name.
      *
-     * @param string $input the string to check
+     * @param string|File $input the input argument File to check
      * @param string|null $type a type hint if the input is a string of known
      * type. This can either be `TYPE_HTML` or `TYPE_XML`. If `null` (default)
      * the type is auto detected from the string content.
@@ -314,7 +315,7 @@ class Pdf
      */
     protected function ensureUrlOrFile($input, $type = null)
     {
-        if (preg_match(self::REGEX_URL, $input)) {
+        if ($input instanceof File || preg_match(self::REGEX_URL, $input)) {
             return $input;
         } elseif ($type === self::TYPE_XML || $type === null && preg_match(self::REGEX_XML, $input)) {
             $ext = '.xml';


### PR DESCRIPTION
* Detection for HTML strings now consistently implemented ~~as `$input !== strip_tags($input)`~~ with Regex
* Same handling for analyzing string content of pages and options like `header-html`
* Check for file arguments with `is_file()` as last resort, if neither URL, HTML or XML
* Where `is_file()` returns `false` the filename is treated like text content
* Complex content can also be passed as a instance of `mikehaertl\tmp\File`.