### PR TITLE
Push version constraints for shellcommand and tmpfile

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.0.0",
-        "mikehaertl/php-tmpfile": "^1.0.0",
-        "mikehaertl/php-shellcommand": "^1.0.2"
+        "mikehaertl/php-tmpfile": "^1.1.0",
+        "mikehaertl/php-shellcommand": "^1.5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* php-shellcommand >= 1.5.0 (Should fix hanging issues)
* php-tmpfile >= 1.1.0 (Better debug options)