### PR TITLE
Update tests due to escaping of all arguments now

### DIFF
--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -139,7 +139,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
 
         $tmpFile = $image->getimageFilename();
         $this->assertFileExists($outFile);
-        $this->assertEquals("$binary --transparent --width '800' --allow '/tmp' --allow '/test' '$inFile' '$tmpFile'", (string) $image->getCommand());
+        $this->assertEquals("$binary '--transparent' '--width' '800' '--allow' '/tmp' '--allow' '/test' '$inFile' '$tmpFile'", (string) $image->getCommand());
         unlink($outFile);
     }
     public function testCanSetOptions()
@@ -164,7 +164,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
 
         $tmpFile = $image->getimageFilename();
         $this->assertFileExists($outFile);
-        $this->assertEquals("$binary --transparent --width '800' --allow '/tmp' --allow '/test' '$inFile' '$tmpFile'", (string) $image->getCommand());
+        $this->assertEquals("$binary '--transparent' '--width' '800' '--allow' '/tmp' '--allow' '/test' '$inFile' '$tmpFile'", (string) $image->getCommand());
         unlink($outFile);
     }
 

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -195,7 +195,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
 
         $tmpFile = $pdf->getPdfFilename();
         $command = (string)$pdf->getCommand();
-        $this->assertEquals("$binary cover '$inFile' '$tmpFile'", $command);
+        $this->assertEquals("$binary 'cover' '$inFile' '$tmpFile'", $command);
         unlink($outFile);
     }
     public function testCanAddCoverFromHtmlString()
@@ -210,7 +210,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($outFile);
 
         $tmpFile = $pdf->getPdfFilename();
-        $this->assertRegExp("#$binary cover '[^ ]+' '$tmpFile'#", (string) $pdf->getCommand());
+        $this->assertRegExp("#$binary 'cover' '[^ ]+' '$tmpFile'#", (string) $pdf->getCommand());
         unlink($outFile);
     }
     public function testCanAddCoverFromUrl()
@@ -226,7 +226,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($outFile);
 
         $tmpFile = $pdf->getPdfFilename();
-        $this->assertEquals("$binary cover '$url' '$tmpFile'", (string) $pdf->getCommand());
+        $this->assertEquals("$binary 'cover' '$url' '$tmpFile'", (string) $pdf->getCommand());
         unlink($outFile);
     }
 
@@ -243,7 +243,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($outFile);
 
         $tmpFile = $pdf->getPdfFilename();
-        $this->assertRegExp("#$binary '[^ ]+' toc '$tmpFile'#", (string) $pdf->getCommand());
+        $this->assertRegExp("#$binary '[^ ]+' 'toc' '$tmpFile'#", (string) $pdf->getCommand());
         unlink($outFile);
     }
 
@@ -287,7 +287,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($pdf->saveAs($outFile));
 
         $this->assertFileExists($outFile);
-        $this->assertRegExp("#$binary --header-html '$tmpDir/tmp_wkhtmlto_pdf_[^ ]+\.html' --no-outline --margin-top '0' --allow '/tmp' --allow '/test' '$inFile' '$tmpDir/tmp_wkhtmlto_pdf_[^ ]+\.pdf'#", (string) $pdf->getCommand());
+        $this->assertRegExp("#$binary '--header-html' '$tmpDir/tmp_wkhtmlto_pdf_[^ ]+\.html' '--no-outline' '--margin-top' '0' '--allow' '/tmp' '--allow' '/test' '$inFile' '$tmpDir/tmp_wkhtmlto_pdf_[^ ]+\.pdf'#", (string) $pdf->getCommand());
         unlink($outFile);
     }
     public function testCanSetGlobalOptions()
@@ -307,7 +307,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($outFile);
 
         $tmpFile = $pdf->getPdfFilename();
-        $this->assertEquals("$binary --no-outline --margin-top '0' '$inFile' '$tmpFile'", (string) $pdf->getCommand());
+        $this->assertEquals("$binary '--no-outline' '--margin-top' '0' '$inFile' '$tmpFile'", (string) $pdf->getCommand());
         unlink($outFile);
     }
     public function testSetPageCoverAndTocOptions()
@@ -344,7 +344,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($outFile);
 
         $tmpFile = $pdf->getPdfFilename();
-        $this->assertEquals("$binary --no-outline --margin-top '0' --header-center 'test {x} {y}' '$inFile' --no-background --zoom '1.5' --cookie 'name' 'value' --replace 'x' 'v' --replace 'y' '' cover '$inFile' --replace 'x' 'a' --replace 'y' 'b' toc --disable-dotted-lines '$tmpFile'", (string) $pdf->getCommand());
+        $this->assertEquals("$binary '--no-outline' '--margin-top' '0' '--header-center' 'test {x} {y}' '$inFile' '--no-background' '--zoom' '1.5' '--cookie' 'name' 'value' '--replace' 'x' 'v' '--replace' 'y' '' 'cover' '$inFile' '--replace' 'x' 'a' '--replace' 'y' 'b' 'toc' '--disable-dotted-lines' '$tmpFile'", (string) $pdf->getCommand());
         unlink($outFile);
     }
     public function testCanAddHeaderAndFooterAsHtml()
@@ -363,7 +363,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($outFile);
 
         $tmpFile = $pdf->getPdfFilename();
-        $this->assertRegExp("#$binary --header-html '/tmp/[^ ]+' --footer-html '/tmp/[^ ]+' '$inFile' '$tmpFile'#", (string) $pdf->getCommand());
+        $this->assertRegExp("#$binary '--header-html' '/tmp/[^ ]+' '--footer-html' '/tmp/[^ ]+' '$inFile' '$tmpFile'#", (string) $pdf->getCommand());
         unlink($outFile);
     }
     public function testCanAddHeaderAndFooterAsFile()
@@ -382,7 +382,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($outFile);
 
         $tmpFile = $pdf->getPdfFilename();
-        $this->assertRegExp("#$binary --header-html '/tmp/[^ ]+' --footer-html '/tmp/[^ ]+' '$inFile' '$tmpFile'#", (string) $pdf->getCommand());
+        $this->assertRegExp("#$binary '--header-html' '/tmp/[^ ]+' '--footer-html' '/tmp/[^ ]+' '$inFile' '$tmpFile'#", (string) $pdf->getCommand());
         unlink($outFile);
     }
     public function testCanAddHeaderAndFooterAsHtmlToPagesAndCoverAndToc()
@@ -410,7 +410,7 @@ class PdfTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($outFile);
 
         $tmpFile = $pdf->getPdfFilename();
-        $this->assertRegExp("#$binary '/tmp/[^ ]+\.html' --header-html '/tmp/[^ ]+\.html' --footer-html '/tmp/[^ ]+\.html' cover '$inFile' --header-html '/tmp/[^ ]+\.html' --footer-html '/tmp/[^ ]+\.html' toc --header-html '/tmp/[^ ]+\.html' --footer-html '/tmp/[^ ]+\.html' '$tmpFile'#", (string) $pdf->getCommand());
+        $this->assertRegExp("#$binary '/tmp/[^ ]+\.html' '--header-html' '/tmp/[^ ]+\.html' '--footer-html' '/tmp/[^ ]+\.html' 'cover' '$inFile' '--header-html' '/tmp/[^ ]+\.html' '--footer-html' '/tmp/[^ ]+\.html' 'toc' '--header-html' '/tmp/[^ ]+\.html' '--footer-html' '/tmp/[^ ]+\.html' '$tmpFile'#", (string) $pdf->getCommand());
         unlink($outFile);
     }
 


### PR DESCRIPTION
Attempt to fix #339 
I still don't understand what's changed upstream, but something is causing the tests to now fail, so here is the fix