### PR TITLE
Added tmpDelete option to avoid delete tmp files

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -287,6 +287,7 @@ class Pdf
     {
         if ($this->_tmpPdfFile === null) {
             $this->_tmpPdfFile = new File('', '.pdf', self::TMP_PREFIX, $this->tmpDir);
+            $this->_tmpPdfFile->delete = $this->tmpDelete;
         }
         return $this->_tmpPdfFile->getFileName();
     }

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -54,6 +54,11 @@ class Pdf
     public $tmpDir;
 
     /**
+     * @var bool delete the temporary files after command finish
+     */
+    public $tmpDelete = true;
+
+    /**
      * @var bool whether to ignore any errors if some PDF file was still
      * created. Default is false.
      */
@@ -233,6 +238,12 @@ class Pdf
             $this->tmpDir = $options['tmpDir'];
             unset($options['tmpDir']);
         }
+
+        if (isset($options['tmpDelete'])) {
+            $this->tmpDelete = $options['tmpDelete'];
+            unset($options['tmpDelete']);
+        }
+
         $options = $this->ensureUrlOrFileOptions($options);
         foreach ($options as $key => $val) {
             if (is_int($key)) {
@@ -343,8 +354,12 @@ class Pdf
             }
             $ext = '.html';
         }
+
         $file = new File($input, $ext, self::TMP_PREFIX, $this->tmpDir);
+        $file->delete = $this->tmpDelete;
+
         $this->_tmpFiles[] = $file;
+
         return $file;
     }
 

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -240,7 +240,7 @@ class Pdf
         }
 
         if (isset($options['tmpDelete'])) {
-            $this->tmpDelete = $options['tmpDelete'];
+            $this->tmpDelete = (bool)$options['tmpDelete'];
             unset($options['tmpDelete']);
         }
 


### PR DESCRIPTION
This new option `tmpDelete` allow to retain tmp HTML  files after PDF is generated.